### PR TITLE
Use standard Python packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
-__pycache__/
-*.pyc
+*.egg-info
 *.json
 *.mov
+*.pyc
 .DS_Store
-.env
 .cursor/
+.env
+__pycache__/
+uv.lock

--- a/README.md
+++ b/README.md
@@ -31,10 +31,16 @@ you can verify the device exists on your machine with:
 
     git clone https://github.com/olvvier/apple-silicon-accelerometer
     cd apple-silicon-accelerometer
-    pip install -r requirements.txt
+    pip install -e .
     sudo python3 motion_live.py
 
 requires root because iokit hid device access on apple silicon needs elevated privileges
+
+### with uv
+
+If you have `uv`/`uvx` installed, you can also just
+
+    sudo uvx git+https://github.com/olvvier/apple-silicon-accelerometer.git
 
 ## code structure
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[project]
+name = "apple-silicon-accelerometer"
+version = "0.1.0"
+license = "MIT"
+description = "reading the undocumented mems accelerometer on apple silicon macbooks via iokit hid"
+authors = [{ name = "Olivier Bourbonnais", email = "olvvier.b@gmail.com"}]
+requires-python = ">=3.12"
+dependencies = ["PyWavelets>=1.4"]
+
+[project.scripts]
+apple-silicon-accelerometer = "motion_live:main"
+
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+py-modules = ["motion_live", "spu_sensor"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-PyWavelets>=1.4


### PR DESCRIPTION
This PR switches `requirements.txt` out for a standard `pyproject.toml` to make things easier to run.

With [uv](https://docs.astral.sh/uv/), you can just `sudo uvx git+https://github.com/akx/apple-silicon-accelerometer@pkg` this branch (if you dare run code as sudo from the internet).