### PR TITLE
Remove root user requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ this project reads both via iokit hid, along with lid angle and ambient light se
     git clone https://github.com/olvvier/apple-silicon-accelerometer
     cd apple-silicon-accelerometer
     python3 -m venv .venv && source .venv/bin/activate
-    pip install -e .[demo]
-    sudo .venv/bin/python3 motion_live.py
+    pip install -e ".[demo]"
+    .venv/bin/python3 motion_live.py
 
 ## what is this
 
@@ -59,7 +59,6 @@ if __name__ == '__main__':
             print(s.x, s.y, s.z)
 ```
 
-requires root (sudo) because iokit hid device access needs elevated privileges.
 note: accelerometer reads ~1g at rest (gravity). use `macimu.filters.remove_gravity()` to isolate dynamic acceleration.
 
 ### check if sensor exists (no root needed)
@@ -245,7 +244,7 @@ if __name__ == '__main__':
     cd apple-silicon-accelerometer
     python3 -m venv .venv && source .venv/bin/activate
     pip install -e .[demo]
-    sudo .venv/bin/python3 motion_live.py
+    .venv/bin/python3 motion_live.py
 
 the demo includes vibration detection, orientation gauges, experimental heartbeat (bcg), lid angle, ambient light, and optional keyboard flash
 
@@ -256,18 +255,18 @@ the repo now vendors KBPulse, including a prebuilt apple silicon binary at `KBPu
 
 run as usual:
 
-    sudo python3 motion_live.py
+    python3 motion_live.py
 
 optional overrides:
 
-    sudo python3 motion_live.py --no-kbpulse
-    sudo python3 motion_live.py --kbpulse-bin /path/to/KBPulse
+    python3 motion_live.py --no-kbpulse
+    python3 motion_live.py --kbpulse-bin /path/to/KBPulse
 
 ### with uv
 
 If you have `uv`/`uvx` installed, you can also just
 
-    sudo uvx git+https://github.com/olvvier/apple-silicon-accelerometer.git
+    uvx git+https://github.com/olvvier/apple-silicon-accelerometer.git
 
 ## code structure
 
@@ -285,7 +284,6 @@ the bcg bandpass is 0.8-3hz and bpm is estimated via autocorrelation on the filt
 ## notes
 
 - experimental / undocumented AppleSPU hid path
-- requires sudo
 - may break on future macos updates
 - use at your own risk
 - not for medical use
@@ -300,6 +298,7 @@ the bcg bandpass is 0.8-3hz and bpm is estimated via autocorrelation on the filt
 
 - intel macs (no spu)
 - m1 macbook pro (2020)
+- m2 macbook pro (2023)
 - mac studio m4 max 
 
 

--- a/macimu/__init__.py
+++ b/macimu/__init__.py
@@ -46,9 +46,6 @@ class SensorNotFound(RuntimeError):
 class IMU:
     """High-level interface to the Apple Silicon SPU IMU.
 
-    Requires root privileges (sudo). Spawns a background worker thread
-    that reads HID reports and writes samples to shared memory.
-
     Parameters
     ----------
     accel : bool
@@ -202,8 +199,6 @@ class IMU:
             return
         if self._mock:
             return
-        if os.geteuid() != 0:
-            raise PermissionError("macimu requires root -- run with sudo")
         if not check_available():
             raise SensorNotFound(
                 "no SPU IMU found -- this machine may not have the sensor")

--- a/motion_live.py
+++ b/motion_live.py
@@ -2,7 +2,6 @@
 """
 demo app for spu_sensor.py - vibration detection, orientation gauges,
 experimental heartbeat (bcg), lid angle & ambient light in a terminal dashboard
-requires: sudo python3 motion_live.py
 """
 
 import time
@@ -542,14 +541,6 @@ class KeyboardFlashBridge:
 
         self.bin_path = bin_path
         cmd = [bin_path, '--stdin-intensity', '--fade-ms', str(self.fade_ms)]
-        sudo_user = os.environ.get('SUDO_USER')
-        if self.run_as_user and os.geteuid() == 0 and sudo_user and sudo_user != 'root':
-            try:
-                pwd.getpwnam(sudo_user)
-                cmd = ['sudo', '-u', sudo_user] + cmd
-                self.run_user = sudo_user
-            except KeyError:
-                self.run_user = None
 
         try:
             self.proc = subprocess.Popen(
@@ -1000,13 +991,9 @@ def main():
         elif arg == '--kbpulse-as-root':
             kbpulse_as_root = True
         elif arg in ('-h', '--help'):
-            print(f'usage: sudo python3 {sys.argv[0]} [--no-kbpulse] [--kbpulse-bin /path/to/KBPulse] [--kbpulse-as-root]')
+            print(f'usage: python3 {sys.argv[0]} [--no-kbpulse] [--kbpulse-bin /path/to/KBPulse] [--kbpulse-as-root]')
             return
         i += 1
-
-    if os.geteuid() != 0:
-        print(f"\033[91m\033[1m[!] run with: sudo python3 {sys.argv[0]}\033[0m")
-        sys.exit(1)
 
     all_shms = [
         (SHM_NAME, SHM_SIZE), (SHM_NAME_GYRO, SHM_SIZE),


### PR DESCRIPTION
The code works with any code requiring the root user removed on Tahoe 26.3. This pull request removes that requirement for root. Related to issue https://github.com/olvvier/apple-silicon-accelerometer/issues/19.